### PR TITLE
Fix ok-to-test command

### DIFF
--- a/.github/workflows/ok-to-test.yaml
+++ b/.github/workflows/ok-to-test.yaml
@@ -16,5 +16,4 @@ jobs:
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: ok-to-test
-          named-args: true
           permission: write


### PR DESCRIPTION
Upgrade from peter-evans/slash-command-dispatch@v1 to peter-evans/slash-command-dispatch@v3 removed the `named-args` parameter which triggered an error