### PR TITLE
👷: Move from kaniko to docker build and push action

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -6,18 +6,35 @@ on:
       - v*
 
 jobs:
-  # Build image and publish it
   docker:
     name: Build and deploy Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Kaniko build
-        uses: aevea/action-kaniko@master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to registry
+        uses: docker/login-action@v2
         with:
-          registry: anx-cr.io
-          image: se-public/cert-manager-webhook-anexia
           username: robot_se-public+github-com
           password: ${{ secrets.REGISTRY_PASSWORD }}
-          strip_tag_prefix: v
-          tag_with_latest: true
+          registry: anx-cr.io
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            anx-cr.io/se-public/cert-manager-webhook-anexia
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Webhook application & image
 
+## [webhook 0.1.5]
+
+### Changed
+* Move from kaniko to docker/build-push-action
+
 ## [webhook 0.1.4]
 
 ### Added
@@ -47,9 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Helm chart to deploy the Anexia cert-manager ACME webhook
 * Role and RoleBinding to read Secrets which are needed to access the Anexia CloudDNS API
 
+[webhook 0.1.5]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.5
 [webhook 0.1.4]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.4
 [webhook 0.1.3]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.3
 [webhook 0.1.0]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.0
+[chart 0.1.5]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-0.1.5
 [chart 0.1.4]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-0.1.4
 [chart 0.1.3]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-0.1.3
 [chart 0.1.1]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-0.1.1

--- a/deploy/cert-manager-webhook-anexia/Chart.yaml
+++ b/deploy/cert-manager-webhook-anexia/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.4"
+appVersion: "0.1.5"
 description: A Helm chart to deploy the Anexia CloudDNS cert-manager ACME solver webhook
 name: cert-manager-webhook-anexia
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: toothstone
     email: fzahn@anexia-it.com

--- a/deploy/cert-manager-webhook-anexia/values.yaml
+++ b/deploy/cert-manager-webhook-anexia/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: anx-cr.io/se-public/cert-manager-webhook-anexia
-  tag: 0.1.4
+  tag: 0.1.5
   pullPolicy: Always
 
 rootCACertificateDuration: 43800h  # 5y


### PR DESCRIPTION
We are using docker/build-push-action throughout our projects, this PR introduces this action also in this repo

It also prepares the code for release `0.1.5`