### PR TITLE
feat: add securityContext options to chart and make it secure by default

### DIFF
--- a/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
@@ -21,8 +21,12 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-anexia.fullname" . }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/deploy/cert-manager-webhook-anexia/values.yaml
+++ b/deploy/cert-manager-webhook-anexia/values.yaml
@@ -44,3 +44,19 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  runAsGroup: 1001
+  runAsUser: 1001
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true


### PR DESCRIPTION
This PR enhances the security of the Helm chart by adding podSecurityContext and container securityContext settings, aligning the deployment with the Kubernetes "restricted" Pod Security Standard by default.

These changes ensure that the webhook runs with the minimum required privileges, reducing the attack surface. The new settings are configurable in values.yaml and include:

   - Pod-level security (`podSecurityContext`):
     - runAsUser, runAsGroup, runAsNonRoot
     - fsGroup
     - seccompProfile set to RuntimeDefault

   - Container-level security (`securityContext`):
     - allowPrivilegeEscalation: false
     - privileged: false
     - readOnlyRootFilesystem: true
     - Dropping all capabilities