### PR TITLE
fix: update kubebuilder test tools download URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,15 @@ envtest: $(ENVTEST)
 $(ENVTEST):
 	GOBIN=$(LOCALBIN) $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-ENVTEST_KUBEBUILDER_ASSETS = KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(KUBE_VERSION) --bin-dir $(LOCALBIN) -p path)"
+define SETUP_ENVTEST_ENV
+	export KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(KUBE_VERSION) --bin-dir $(LOCALBIN) -p path)" && \
+	export TEST_ASSET_ETCD="$$KUBEBUILDER_ASSETS/etcd" && \
+	export TEST_ASSET_KUBE_APISERVER="$$KUBEBUILDER_ASSETS/kube-apiserver" && \
+	export TEST_ASSET_KUBECTL="$$KUBEBUILDER_ASSETS/kubectl"
+endef
 
 test: envtest
-	$(ENVTEST_KUBEBUILDER_ASSETS) $(GO) test -v -tags=integration,unit . -coverprofile coverage.out
+	$(SETUP_ENVTEST_ENV) && $(GO) test -v -tags=integration,unit . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 test-unit:
@@ -31,7 +36,7 @@ test-unit:
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 test-integration: envtest
-	$(ENVTEST_KUBEBUILDER_ASSETS) $(GO) test -v -tags=integration . -coverprofile coverage.out
+	$(SETUP_ENVTEST_ENV) && $(GO) test -v -tags=integration . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 clean: clean-kubebuilder

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,27 @@ IMAGE_NAME := "anx-cr.io/se-public/cert-manager-webhook-anexia"
 IMAGE_TAG := "latest"
 
 OUT := $(shell pwd)/_out
+LOCALBIN := $(shell pwd)/_test
 
-KUBE_VERSION=1.30.0
+KUBE_VERSION=1.30
 
 $(shell mkdir -p "$(OUT)")
-export TEST_ASSET_ETCD=_test/kubebuilder/etcd
-export TEST_ASSET_KUBE_APISERVER=_test/kubebuilder/kube-apiserver
-export TEST_ASSET_KUBECTL=_test/kubebuilder/kubectl
+$(shell mkdir -p "$(LOCALBIN)")
 
-test: _test/kubebuilder
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+.PHONY: envtest
+envtest: $(ENVTEST)
+$(ENVTEST):
+	GOBIN=$(LOCALBIN) $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+ENVTEST_ASSETS = $(shell $(ENVTEST) use $(KUBE_VERSION) --bin-dir $(LOCALBIN) -p path 2>/dev/null)
+
+test: envtest
+	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS)" \
+	TEST_ASSET_ETCD="$(ENVTEST_ASSETS)/etcd" \
+	TEST_ASSET_KUBE_APISERVER="$(ENVTEST_ASSETS)/kube-apiserver" \
+	TEST_ASSET_KUBECTL="$(ENVTEST_ASSETS)/kubectl" \
 	$(GO) test -v -tags=integration,unit . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
@@ -22,22 +34,18 @@ test-unit:
 	$(GO) test -v . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
-test-integration: _test/kubebuilder
+test-integration: envtest
+	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS)" \
+	TEST_ASSET_ETCD="$(ENVTEST_ASSETS)/etcd" \
+	TEST_ASSET_KUBE_APISERVER="$(ENVTEST_ASSETS)/kube-apiserver" \
+	TEST_ASSET_KUBECTL="$(ENVTEST_ASSETS)/kubectl" \
 	$(GO) test -v -tags=integration . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
-
-_test/kubebuilder:
-	curl -fsSL https://go.kubebuilder.io/test-tools/$(KUBE_VERSION)/$(OS)/$(ARCH) -o kubebuilder-tools.tar.gz
-	mkdir -p _test/kubebuilder
-	tar -xvf kubebuilder-tools.tar.gz
-	mv kubebuilder/bin/* _test/kubebuilder/
-	rm kubebuilder-tools.tar.gz
-	rm -R kubebuilder
 
 clean: clean-kubebuilder
 
 clean-kubebuilder:
-	rm -Rf _test/kubebuilder
+	rm -Rf _test
 
 build:
 	docker build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,10 @@ envtest: $(ENVTEST)
 $(ENVTEST):
 	GOBIN=$(LOCALBIN) $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-ENVTEST_ASSETS = $(shell $(ENVTEST) use $(KUBE_VERSION) --bin-dir $(LOCALBIN) -p path 2>/dev/null)
+ENVTEST_KUBEBUILDER_ASSETS = KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(KUBE_VERSION) --bin-dir $(LOCALBIN) -p path)"
 
 test: envtest
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS)" \
-	TEST_ASSET_ETCD="$(ENVTEST_ASSETS)/etcd" \
-	TEST_ASSET_KUBE_APISERVER="$(ENVTEST_ASSETS)/kube-apiserver" \
-	TEST_ASSET_KUBECTL="$(ENVTEST_ASSETS)/kubectl" \
-	$(GO) test -v -tags=integration,unit . -coverprofile coverage.out
+	$(ENVTEST_KUBEBUILDER_ASSETS) $(GO) test -v -tags=integration,unit . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 test-unit:
@@ -35,11 +31,7 @@ test-unit:
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 test-integration: envtest
-	KUBEBUILDER_ASSETS="$(ENVTEST_ASSETS)" \
-	TEST_ASSET_ETCD="$(ENVTEST_ASSETS)/etcd" \
-	TEST_ASSET_KUBE_APISERVER="$(ENVTEST_ASSETS)/kube-apiserver" \
-	TEST_ASSET_KUBECTL="$(ENVTEST_ASSETS)/kubectl" \
-	$(GO) test -v -tags=integration . -coverprofile coverage.out
+	$(ENVTEST_KUBEBUILDER_ASSETS) $(GO) test -v -tags=integration . -coverprofile coverage.out
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 clean: clean-kubebuilder


### PR DESCRIPTION
## Summary

- Fix broken kubebuilder test tools download

## Problem

Noticed in PR #34 that CI tests fail because the kubebuilder-tools GCS bucket (`https://go.kubebuilder.io/test-tools/...`) returns 403 Forbidden.

## Solution

Replace direct curl download with `setup-envtest` from controller-runtime, which is the [official recommended approach](https://book.kubebuilder.io/reference/envtest.html):
- Install `setup-envtest` via `go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest`
- Use it to download and manage kubebuilder test binaries
- Set `TEST_ASSET_*` env vars for cert-manager test compatibility