### PR TITLE
feat(helm): add podLabels support for custom pod labels

### DIFF
--- a/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: {{ include "cert-manager-webhook-anexia.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "cert-manager-webhook-anexia.fullname" . }}
       securityContext:

--- a/deploy/cert-manager-webhook-anexia/values.yaml
+++ b/deploy/cert-manager-webhook-anexia/values.yaml
@@ -24,6 +24,8 @@ servingCertificateDuration: 8760h # 1y
 nameOverride: ""
 fullnameOverride: ""
 
+podLabels: {}
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
## Summary

- Add `podLabels` field to Helm chart values to allow custom labels on pods

## Changes

- `values.yaml`: Added `podLabels: {}` configuration option
- `deployment.yaml`: Updated pod template to merge custom podLabels into metadata

## Note

The failing CI job is fixed in PR #35.

---

Supersedes #34 (recreated from the repo directly to enable CI integration checks).