### PR TITLE
chore(helm): migrate Chart.yaml to apiVersion v2

### DIFF
--- a/deploy/cert-manager-webhook-anexia/Chart.yaml
+++ b/deploy/cert-manager-webhook-anexia/Chart.yaml
@@ -1,7 +1,8 @@
 ---
-apiVersion: v1
+apiVersion: v2
+type: application
 appVersion: "1.0.2"
 description: A Helm chart to deploy the Anexia CloudDNS cert-manager ACME solver webhook
 name: cert-manager-webhook-anexia
-version: 1.0.4
+version: 1.0.5
 maintainers: []


### PR DESCRIPTION
## Summary
- Upgrade Chart.yaml from legacy `apiVersion: v1` to `v2` (Helm 3 standard)
- Add required `type: application` field
- Bump chart version to 1.0.5

`apiVersion: v1` is the legacy format from the Helm 2 era. Since the chart already requires Helm 3, this aligns the metadata with the tooling.