### PR TITLE
feat: inject version at build time via ldflags

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -10,6 +10,8 @@ jobs:
     name: Build and deploy Docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to registry
@@ -35,6 +37,9 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,11 @@ RUN go mod download
 
 FROM build_deps AS build
 
+ARG VERSION=dev
+
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
+RUN CGO_ENABLED=0 go build -o webhook -ldflags "-w -extldflags '-static' -X main.Version=${VERSION}" .
 
 FROM alpine:3.23
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean-kubebuilder:
 	rm -Rf _test
 
 build:
-	docker build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
+	docker build --build-arg VERSION="$(IMAGE_TAG)" -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
 
 .PHONY: rendered-manifest.yaml
 rendered-manifest.yaml:

--- a/main.go
+++ b/main.go
@@ -24,6 +24,9 @@ import (
 	anxcloudDns "go.anx.io/go-anxcloud/pkg/apis/clouddns/v1"
 )
 
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
 var GroupName = os.Getenv("GROUP_NAME")
 
 const Timeout = 30 * time.Second
@@ -32,6 +35,8 @@ func main() {
 	if GroupName == "" {
 		panic("GROUP_NAME must be specified")
 	}
+
+	klog.Infof("cert-manager-webhook-anexia %s", Version)
 
 	// This will register our custom DNS provider with the webhook serving
 	// library, making it available as an API under the provided GroupName.


### PR DESCRIPTION
## Summary
- Add a `Version` variable to `main.go` that gets logged at startup
- Inject the version via `-ldflags -X main.Version=...` in the Dockerfile, CI workflow, and Makefile
- Defaults to `dev` for local builds without explicit flags

This makes it possible to verify which version is running in a cluster by checking the webhook's logs.