### PR TITLE
chore(release): chart 1.0.6 with app version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Webhook application & image
 
+## [webhook 1.1.0]
+
+### Changed
+* Upgrade Go 1.19 to 1.26 and all major dependencies
+* Inject version at build time via ldflags
+* Update base images (golang 1.26-alpine, alpine 3.23)
+
 ## [webhook 1.0.0]
 
 ### Changed
@@ -44,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Helm chart
 
+## [chart 1.0.6]
+* Update image to app version 1.1.0
+* Migrate Chart.yaml to apiVersion v2
+
 ## [chart 1.0.4] (including earlier patch releases)
 * Fix several deployment issues
 * Set default port to unprivileged port 8080
@@ -66,11 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Helm chart to deploy the Anexia cert-manager ACME webhook
 * Role and RoleBinding to read Secrets which are needed to access the Anexia CloudDNS API
 
+[webhook 1.1.0]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v1.1.0
 [webhook 1.0.0]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v1.0.0
 [webhook 0.1.5]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.5
 [webhook 0.1.4]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.4
 [webhook 0.1.3]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.3
 [webhook 0.1.0]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/v0.1.0
+[chart 1.0.6]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-1.0.6
 [chart 1.0.4]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-1.0.4
 [chart 1.0.0]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-1.0.0
 [chart 0.1.5]: https://github.com/anexia-it/cert-manager-webhook-anexia/releases/tag/cert-manager-webhook-anexia-0.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [chart 1.0.6]
 * Update image to app version 1.1.0
 * Migrate Chart.yaml to apiVersion v2
+* Add `podAnnotations` value to set annotations on the webhook pod
 
 ## [chart 1.0.4] (including earlier patch releases)
 * Fix several deployment issues

--- a/deploy/cert-manager-webhook-anexia/Chart.yaml
+++ b/deploy/cert-manager-webhook-anexia/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 type: application
-appVersion: "1.0.2"
+appVersion: "1.1.0"
 description: A Helm chart to deploy the Anexia CloudDNS cert-manager ACME solver webhook
 name: cert-manager-webhook-anexia
-version: 1.0.5
+version: 1.0.6
 maintainers: []

--- a/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-anexia/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "cert-manager-webhook-anexia.name" . }}
         release: {{ .Release.Name }}

--- a/deploy/cert-manager-webhook-anexia/values.yaml
+++ b/deploy/cert-manager-webhook-anexia/values.yaml
@@ -15,7 +15,7 @@ certManager:
 
 image:
   repository: anx-cr.io/se-public/cert-manager-webhook-anexia
-  tag: 1.0.2
+  tag: 1.1.0
   pullPolicy: Always
 
 rootCACertificateDuration: 43800h # 5y

--- a/deploy/cert-manager-webhook-anexia/values.yaml
+++ b/deploy/cert-manager-webhook-anexia/values.yaml
@@ -26,6 +26,8 @@ fullnameOverride: ""
 
 podLabels: {}
 
+podAnnotations: {}
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
Releases chart 1.0.6 referencing the new app image 1.1.0 (published from tag v1.1.0).

- Bump image tag and appVersion to 1.1.0
- Bump chart version to 1.0.6
- Add changelog entries for webhook 1.1.0 and chart 1.0.6

Merging this will trigger chart-releaser to publish chart 1.0.6.